### PR TITLE
Set consistency to a batch Statement. Options of each Statement are igno...

### DIFF
--- a/stratio-sinks/stratio-cassandra-sink/src/main/java/com/stratio/ingestion/sink/cassandra/CassandraRepository.java
+++ b/stratio-sinks/stratio-cassandra-sink/src/main/java/com/stratio/ingestion/sink/cassandra/CassandraRepository.java
@@ -102,9 +102,10 @@ class CassandraRepository {
 			BatchStatement batch = new BatchStatement();
 			for (CassandraRow row : rows) {
 				Insert buildInsert = buildInsert(row, this.keyspace,
-						this.table, this.consistencyLevel);
+						this.table);
 				batch.add(buildInsert);
 			}
+			batch.setConsistencyLevel(ConsistencyLevel.valueOf(this.consistencyLevel));
 			this.session.executeAsync(batch);
 		} catch (Exception e) {
 			throw new CassandraSinkException(e);
@@ -123,9 +124,8 @@ class CassandraRepository {
 
 	@SuppressWarnings("rawtypes")
 	private static final Insert buildInsert(CassandraRow row, String keyspace,
-			String table, String consistencyLevel) {
+			String table) {
 		Insert insert = QueryBuilder.insertInto(keyspace, table);
-		insert.setConsistencyLevel(ConsistencyLevel.valueOf(consistencyLevel));
 		for (CassandraField field : row.getFields()) {
 			insert.value(field.getColumnName(), field.getValue());
 		}


### PR DESCRIPTION
Change setConsistencyLevel from InsertStatement level to BachStatement  level. According to Datastax-Java-Driver doc (http://www.datastax.com/drivers/java/2.0/com/datastax/driver/core/BatchStatement.html#add(com.datastax.driver.core.Statement) InsertStatement options will be ignored in BatchStatement.
