### PR TITLE
Add option to ignore case column names in Cassandra sink

### DIFF
--- a/stratio-sinks/stratio-cassandra-sink/README.md
+++ b/stratio-sinks/stratio-cassandra-sink/README.md
@@ -23,6 +23,8 @@ The available config parameters are:
 
 - cqlFile: Path to a CQL file with initialization statements such as keyspace and table creation. (Optional)
 
+- ignoreCase (true|false): match the event columns and table columns ignoring case. It has worst performance so it's recommended to use lower case in event headers if possible (Cassandra returns column names in lower case). (Default: false). 
+
 Sample Complete-flow Flume config
 =================================
 

--- a/stratio-sinks/stratio-cassandra-sink/src/main/java/com/stratio/ingestion/sink/cassandra/CassandraSink.java
+++ b/stratio-sinks/stratio-cassandra-sink/src/main/java/com/stratio/ingestion/sink/cassandra/CassandraSink.java
@@ -58,6 +58,7 @@ public class CassandraSink extends AbstractSink implements Configurable {
   private static final int DEFAULT_BATCH_SIZE = 100;
   private static final String DEFAULT_CONSISTENCY_LEVEL = ConsistencyLevel.QUORUM.name();
   private static final String DEFAULT_BODY_COLUMN = null;
+  private static final boolean DEFAULT_IGNORE_CASE_OPTION = false;
 
   private static final String CONF_TABLES = "tables";
   private static final String CONF_HOSTS = "hosts";
@@ -67,6 +68,7 @@ public class CassandraSink extends AbstractSink implements Configurable {
   private static final String CONF_CQL_FILE = "cqlFile";
   private static final String CONF_CONSISTENCY_LEVEL = "consistency";
   private static final String CONF_BODY_COLUMN = "bodyColumn";
+  private static final String CONF_IGNORE_CASE = "ignoreCase";
   Cluster cluster;
   Session session;
   List<CassandraTable> tables;
@@ -80,6 +82,7 @@ public class CassandraSink extends AbstractSink implements Configurable {
   private String consistency;
   private String bodyColumn;
   private final CounterGroup counterGroup = new CounterGroup();
+  private boolean ignoreCase;
 
   public CassandraSink() {
     super();
@@ -102,6 +105,7 @@ public class CassandraSink extends AbstractSink implements Configurable {
     this.password = context.getString(CONF_PASSWORD);
     this.consistency = context.getString(CONF_CONSISTENCY_LEVEL, DEFAULT_CONSISTENCY_LEVEL);
     this.bodyColumn = context.getString(CONF_BODY_COLUMN, DEFAULT_BODY_COLUMN);
+    this.ignoreCase = context.getBoolean(CONF_IGNORE_CASE, DEFAULT_IGNORE_CASE_OPTION);
 
     final String tablesString = StringUtils.trimToNull(context.getString(CONF_TABLES));
     if (tablesString == null) {
@@ -146,7 +150,7 @@ public class CassandraSink extends AbstractSink implements Configurable {
       final String keyspace = fields[0];
       final String table = fields[1];
       final TableMetadata tableMetadata = getTableMetadata(session, keyspace, table);
-      tables.add(new CassandraTable(session, tableMetadata, ConsistencyLevel.valueOf(consistency), bodyColumn));
+      tables.add(new CassandraTable(session, tableMetadata, ConsistencyLevel.valueOf(consistency), bodyColumn, ignoreCase));
     }
 
     this.sinkCounter.start();


### PR DESCRIPTION
Using flume with Cassandra sink is typical to have no results because the names in the flume event are not in lower caser and Cassandra use lower_case by default. 
The logs only shows: "Event {} could not be mapped" so it's difficult to notice what is going on.

A new configuration option is added to avoid this problem transforming all the event keys to lower case (with some performance cost --> copy a complete map).

Added information in readme also.